### PR TITLE
feat: implement transactions endpoint

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -127,10 +127,14 @@ func (c *Controller) setupServices() (*service.Service, error) {
 }
 
 func (c *Controller) configureRouter(ctx context.Context, r *redis.Client, l logger.Logger) {
-	handler := handler.NewHandler(ctx, r, l)
+	//Initialize handler with needed services
+	txService := service.NewTransactionService(ctx, r, l)
+	handler := handler.NewHandler(txService)
 
-	route.RegisterRoutes(c.router, &handler)
+	// Register all routes
+	route.RegisterRoutes(c.router, handler)
 
+	// Configure server
 	c.httpServer = &http.Server{
 		Addr:         fmt.Sprintf(":%s", os.Getenv("PORT")),
 		Handler:      c.router,

--- a/internal/controller/handler/handler.go
+++ b/internal/controller/handler/handler.go
@@ -14,14 +14,14 @@ type Handler struct {
 }
 
 func (h *Handler) GetLatestTransactions(c *gin.Context) {
-	var rangeArgs model.RangeArgs
-	if err := c.ShouldBindQuery(&rangeArgs); err != nil {
+	var txCount model.CountArgs
+	if err := c.ShouldBindJSON(&txCount); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid range parameters"})
 		return
 	}
 
 	ctx := c.Request.Context()
-	txs, err := h.TxService.GetLatestTransactions(ctx, rangeArgs.Start, rangeArgs.Stop)
+	txs, err := h.TxService.GetLatestNTransactions(ctx, txCount.TxCount)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/controller/routes/routes.go
+++ b/internal/controller/routes/routes.go
@@ -13,5 +13,5 @@ func RegisterRoutes(router *gin.Engine, handler *handler.Handler) {
 		ctx.String(http.StatusOK, "pong")
 	})
 
-	router.GET("/transactions", handler.TransactionService.GetLatestTransactions)
+	router.GET("/transactions", handler.GetLatestTransactions)
 }

--- a/internal/model/redis_model.go
+++ b/internal/model/redis_model.go
@@ -103,7 +103,6 @@ type GroupedTransactions struct {
 	} `json:"stats"`
 }
 
-type RangeArgs struct {
-	Start int64 `form:"start"`
-	Stop  int64 `form:"stop"`
+type CountArgs struct {
+	TxCount int64 `json:"tx_count" binding:"required"`
 }

--- a/internal/model/redis_model.go
+++ b/internal/model/redis_model.go
@@ -102,3 +102,8 @@ type GroupedTransactions struct {
 		GroupCount        int   `json:"group_count"`
 	} `json:"stats"`
 }
+
+type RangeArgs struct {
+	Start int64 `form:"start"`
+	Stop  int64 `form:"stop"`
+}

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -3,33 +3,40 @@ package service
 import (
 	"context"
 	"txpool-viz/internal/logger"
+	"txpool-viz/utils"
 
-	"github.com/gin-gonic/gin"
 	"github.com/redis/go-redis/v9"
 )
 
-// const (
-// 	pending = "pending"
-// 	queued  = "queued"
-// )
-
-type transactionServiceImpl struct {
+type TransactionServiceImpl struct {
 	redis  *redis.Client
 	logger logger.Logger
 }
 
 // NewTransactionService creates a new transaction service
-func NewTransactionService(ctx context.Context, r *redis.Client, l logger.Logger) *transactionServiceImpl {
-	return &transactionServiceImpl{
+func NewTransactionService(ctx context.Context, r *redis.Client, l logger.Logger) *TransactionServiceImpl {
+	return &TransactionServiceImpl{
 		redis:  r,
 		logger: l,
 	}
 }
 
 // GetLatestTransactions handles the request to get the latest transactions
-func (ts *transactionServiceImpl) GetLatestTransactions(ctx *gin.Context) {
-	// This needs to supply a list of recent transactions
+func (ts *TransactionServiceImpl) GetLatestTransactions(ctx context.Context, start int64, stop int64) ([]string, error) {
+	if stop == 0 {
+		stop = -1
+	}
 
-	// It will pull that from a queue
-	ts.logger.Info("REST API Exposed")
+	results, err := ts.redis.ZRangeWithScores(ctx, utils.RedisUniversalKey(), start, stop).Result()
+	if err != nil {
+		ts.logger.Error("Redis ZRangeWithScores failed", err)
+		return nil, err
+	}
+
+	var hashes []string
+	for _, z := range results {
+		hashes = append(hashes, z.Member.(string))
+	}
+
+	return hashes, nil
 }

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -21,11 +21,9 @@ func NewTransactionService(ctx context.Context, r *redis.Client, l logger.Logger
 	}
 }
 
-// GetLatestTransactions handles the request to get the latest transactions
-func (ts *TransactionServiceImpl) GetLatestTransactions(ctx context.Context, start int64, stop int64) ([]string, error) {
-	if stop == 0 {
-		stop = -1
-	}
+func (ts *TransactionServiceImpl) GetLatestNTransactions(ctx context.Context, n int64) ([]string, error) {
+	start := -n
+	stop := int64(-1)
 
 	results, err := ts.redis.ZRangeWithScores(ctx, utils.RedisUniversalKey(), start, stop).Result()
 	if err != nil {
@@ -38,5 +36,6 @@ func (ts *TransactionServiceImpl) GetLatestTransactions(ctx context.Context, sta
 		hashes = append(hashes, z.Member.(string))
 	}
 
+	ts.logger.Info("GetLatestNTransactions called")
 	return hashes, nil
 }

--- a/internal/transactions/stream.go
+++ b/internal/transactions/stream.go
@@ -14,14 +14,8 @@ import (
 	"txpool-viz/utils"
 
 	"github.com/coder/websocket"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/redis/go-redis/v9"
 )
-
-type Result struct {
-	Pending map[string]map[string]*types.Transaction `json:"pending"`
-	Queued  map[string]map[string]*types.Transaction `json:"queued"`
-}
 
 func Stream(ctx context.Context, cfg *config.Config, srvc *service.Service) {
 	// Start listening to txhashes


### PR DESCRIPTION
This PR implements the `transactions` endpoint.

It fetches an array of `n` transaction hashes that have been detected by the tool and sorted in descending order according to the timestamp at which it was first detected. 

At the writing of this PR, this data lives in the a redis sorted list specified here 

https://github.com/punkhazardlabs/txpool-viz/blob/952a212d95434493e3933e67153c721daeb71328/utils/redis_prefixes.go#L10