### PR TITLE
fix: use static binary for binary build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TAG ?= dev
 
 # Go build for local
 build:
-	GOOS=linux GOARCH=amd64 go build -o bin/$(BINARY_NAME) cmd/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/$(BINARY_NAME) cmd/main.go
 
 # Clean build artifacts
 clean:


### PR DESCRIPTION
The current way of compiling the tool only includes binaries for the host system. This change makes the binary compiled fully selfcontained and ready to run on any image.