### PR TITLE
fix(ui): transaction details visibility in dark mode

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -11,6 +11,9 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  --background-dark: #1a1a1a;
+  --background-light: #ffffff;
 }
 
 a {

--- a/frontend/src/routes/TransactionsView.svelte
+++ b/frontend/src/routes/TransactionsView.svelte
@@ -57,7 +57,7 @@
 
     {#if txDetails[selectedTx]}
       {#each Object.entries(txDetails[selectedTx]) as [endpoint, detail]}
-        <section>
+        <section class="details-pane">
           <strong>{endpoint}</strong>
           <pre>{JSON.stringify(detail, null, 2)}</pre>
         </section>
@@ -84,5 +84,11 @@
     border-left: 1px solid #ddd;
     padding: 1rem;
     overflow-y: auto;
+  }
+  .details-pane{
+    background: var(--background-light);
+    @media (prefers-color-scheme: dark) {
+    background: var(--background-dark);
+  }
   }
 </style>


### PR DESCRIPTION
- Update pane background and text colors for dark theme.

When macOS is in dark mode, transaction details become invisible in the pane, I am using Helium browser, behavior may vary in other browsers.